### PR TITLE
Update __init__.py (remove(path), copy())

### DIFF
--- a/src/datoso/helpers/__init__.py
+++ b/src/datoso/helpers/__init__.py
@@ -95,7 +95,12 @@ class FileUtils:
         """ Copy file to destination. """
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         try:
-            shutil.copy(origin, destination)
+            if os.path.isdir(origin):
+                with suppress(FileNotFoundError):
+                    shutil.rmtree(destination)
+                shutil.copytree(origin, destination)
+            else:
+                shutil.copy(origin, destination)
         except shutil.SameFileError:
             pass
         except IsADirectoryError:
@@ -115,7 +120,10 @@ class FileUtils:
     def remove(path):
         """ Remove file or folder. """
         try:
-            os.unlink(path)
+            if os.path.isdir(path):
+                FileUtils.remove_folder(path)
+            else:
+                os.unlink(path)
         except IsADirectoryError:
             FileUtils.remove_folder(path)
         except FileNotFoundError:

--- a/src/datoso/helpers/__init__.py
+++ b/src/datoso/helpers/__init__.py
@@ -103,10 +103,6 @@ class FileUtils:
                 shutil.copy(origin, destination)
         except shutil.SameFileError:
             pass
-        except IsADirectoryError:
-            with suppress(FileNotFoundError):
-                shutil.rmtree(destination)
-            shutil.copytree(origin, destination)
         except FileNotFoundError:
             raise FileNotFoundError(f"File {origin} not found.")
 
@@ -119,15 +115,12 @@ class FileUtils:
     @staticmethod
     def remove(path):
         """ Remove file or folder. """
-        try:
-            if os.path.isdir(path):
-                FileUtils.remove_folder(path)
-            else:
-                os.unlink(path)
-        except IsADirectoryError:
+        if not os.path.exists(path):  
+            return
+        if os.path.isdir(path):
             FileUtils.remove_folder(path)
-        except FileNotFoundError:
-            pass
+        else:
+            os.unlink(path)
 
     @staticmethod
     def parse_folder(path) -> str:


### PR DESCRIPTION
remove(path): Windows throws a PermissionError if attempting to execute os.unlink(path) on a path with read-only files, like the ones from the Pleasuredome seed after extraction. The test for isdir() lets us bypass this and throw it straight to remove_folder(path), which handles this situation without an error. 
Windows workaround also required in copy() function to avoid attempting to use a file handler on a folder.