### PR TITLE
Ignore parentheses inside string (DAT file processing)

### DIFF
--- a/src/datoso/repositories/dat.py
+++ b/src/datoso/repositories/dat.py
@@ -264,12 +264,15 @@ class ClrMameProDatFile(DatFile):
         parenthesis = 0
         start = 0
         end = 0
+        within_string = 0
         for i, char in enumerate(data):
-            if char == '(':
+            if char == '"':
+                within_string = not(within_string)
+            if char == '(' and within_string == 0:
                 if parenthesis == 0:
                     start = i + 1
                 parenthesis += 1
-            if char == ')':
+            if char == ')' and within_string == 0:
                 parenthesis -= 1
             if parenthesis == 0 and start >= 1:
                 end = i

--- a/src/datoso/repositories/dat.py
+++ b/src/datoso/repositories/dat.py
@@ -264,16 +264,17 @@ class ClrMameProDatFile(DatFile):
         parenthesis = 0
         start = 0
         end = 0
-        within_string = 0
+        within_string = False
         for i, char in enumerate(data):
             if char == '"':
                 within_string = not(within_string)
-            if char == '(' and within_string == 0:
-                if parenthesis == 0:
-                    start = i + 1
-                parenthesis += 1
-            if char == ')' and within_string == 0:
-                parenthesis -= 1
+            if not within_string:
+                if char == '(':
+                    if parenthesis == 0:
+                        start = i + 1
+                    parenthesis += 1
+                if char == ')':
+                    parenthesis -= 1
             if parenthesis == 0 and start >= 1:
                 end = i
                 break


### PR DESCRIPTION
Fix for separating blocks within a string section; if within a string, it will not add or remove counts. This works around an issue where an unclosed parenthesis exists; this can only happen in a string, as otherwise it would break the DAT structure. Example string fixed: "name "M1ab Test Rom (Maygay)( [Rom]" (from pleasuredome FruitMachine dat file)